### PR TITLE
Updated the client ID

### DIFF
--- a/resources/js/components/MinetteCard.vue
+++ b/resources/js/components/MinetteCard.vue
@@ -37,12 +37,13 @@
             },
 
             askMinetteWithClientToken(relation) {
+                // Client Secret for Client ID 2
                 const clientSecret = 'a6rSGoOUwafp0bRWzI6so7lLjcnSuOfmApCYrchm';
                 const password = window.user.name.split('@')[0].toLowerCase();
 
                 axios.post(baseUrl + 'oauth/token', {
                     'grant_type': 'password',
-                    'client_id': 'minou-password',
+                    'client_id': 2,
                     'client_secret': clientSecret,
                     'username': window.user.name,
                     'password': password,


### PR DESCRIPTION
The client ID must be the ID, not the client name. By default, Laravel Passport create two clients: the client ID 2 is the Minou Password Grant Client.